### PR TITLE
Change submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "polarssl"]
 	path = polarssl
-	url = git@github.com:ARMmbed/mbedtls.git
+	url = https://github.com/ARMmbed/mbedtls.git


### PR DESCRIPTION
I think ssh url is user-unfriendly for travis or other ci environments.
