### PR TITLE
Fix unfound mruby-string-ext & header io.h

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -77,8 +77,8 @@ MRuby::Gem::Specification.new('mruby-polarssl') do |spec|
     #{polarssl_src}/library/xtea.c
   ).map { |f| f.relative_path_from(dir).pathmap("#{build_dir}/%X.o") }
 
-  spec.add_dependency('mruby-string-ext')
-  spec.add_dependency('mruby-io')
-  spec.add_dependency('mruby-socket')
-  spec.add_dependency('mruby-mtest')
+  spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
+  spec.add_dependency 'mruby-io', :mgem => 'mruby-io'
+  spec.add_dependency 'mruby-socket', :mgem => 'mruby-socket'
+  spec.add_dependency 'mruby-mtest', :mgem => 'mruby-mtest'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,6 +5,7 @@ MRuby::Gem::Specification.new('mruby-polarssl') do |spec|
   polarssl_dirname = 'polarssl'
   polarssl_src = "#{spec.dir}/#{polarssl_dirname}"
   spec.cc.include_paths << "#{polarssl_src}/include"
+  spec.cc.include_paths << "#{polarssl_src}/../../mruby-io/include"
   spec.cc.include_paths << "#{build.root}/src"
   spec.cc.flags << '-D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement'
 


### PR DESCRIPTION
When using it with mruby-cli I got 2 errors:
- The first one because `mruby-string-ext` was not found in mrbgems list. The fix consists in saying it's a core mrbgem.
- The second one because the `mruby/ext/io.h` header was not found. After inspecting the include paths passed to the compiler, it appeared that `mruby-io` headers path was not provided.
