### PR TITLE
Fix memory leaks

### DIFF
--- a/src/polarssl.c
+++ b/src/polarssl.c
@@ -40,6 +40,7 @@ static void mrb_ssl_free(mrb_state *mrb, void *ptr) {
 
   if (ssl != NULL) {
     ssl_free(ssl);
+    mrb_free(mrb, ssl);
   }
 }
 
@@ -293,7 +294,6 @@ static mrb_value mrb_ssl_close(mrb_state *mrb, mrb_value self) {
   ssl_context *ssl;
 
   ssl = DATA_CHECK_GET_PTR(mrb, self, &mrb_ssl_type, ssl_context);
-  memset(ssl, 0, sizeof(ssl_context));
   return mrb_true_value();
 }
 


### PR DESCRIPTION
I fixed memory leaks :
- Free `ssl` allocated in `mrb_ssl_initialize`
- Not zeroize `ssl_context` in `mrb_ssl_close` to free `ssl_context->in_ctr` and `ssl_context->out_ctr` in `ssl_free`(in `polarssl/library/ssl_tls.c`)