### PR TITLE
Clear `ssl->conf` after free

### DIFF
--- a/src/polarssl.c
+++ b/src/polarssl.c
@@ -45,6 +45,7 @@ static void mrb_ssl_free(mrb_state *mrb, void *ptr) {
     if (ssl->conf != NULL) {
       mbedtls_ssl_config_free((mbedtls_ssl_config  *)ssl->conf);
       mrb_free(mrb, (mbedtls_ssl_config  *)ssl->conf);
+      ssl->conf = NULL;
     }
 
     mbedtls_ssl_free(ssl);


### PR DESCRIPTION
Seems debug things in polarssl use them when it's not `NULL`.